### PR TITLE
Update version of ethereumjs-tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "^2.0.1",
     "ethereum-common": "0.0.18",
-    "ethereumjs-tx": "^1.0.0",
+    "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"
   },


### PR DESCRIPTION
If `ethereumjs-tx@1.0.0` will be installed `verifySignature` will return wrong result.
This PR update `ethereumjs-tx` version ([EIP155 support was added](https://github.com/ethereumjs/ethereumjs-tx/pull/41)).