### PR TITLE
[Pre-Byzantium Release] [WIP] v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 [1.7.0]: https://github.com/ethereumjs/ethereumjs-vm/compare/v1.6.0...v1.7.0
 
+## [1.6.1] - 2017-09-19
+- Tightened dependencies to prevent the ``1.6.x`` version of the library to break
+  after ``ethereumjs`` Byzantium library updates
+
+[1.6.1]: https://github.com/ethereumjs/ethereumjs-block/compare/v1.6.0...v1.6.1
+
 ## [1.6.0] - 2017-07-12
 - Breakout header-from-rpc as separate module
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-block",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Provides Block serialization and help functions",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
   "dependencies": {
     "async": "^2.0.1",
     "ethereum-common": "0.0.18",
-    "ethereumjs-tx": "^1.2.2",
+    "ethereumjs-tx": "~1.3.0",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"
   },


### PR DESCRIPTION
Tightened dependencies to prevent the ``1.6.x`` version of the library to break
after ``ethereumjs`` Byzantium library updates