### PR TITLE
fix tx.serialize()

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ Block.prototype.genTxTrie = function (cb) {
   var self = this
 
   async.eachSeries(this.transactions, function (tx, done) {
-    self.txTrie.put(rlp.encode(i), tx.serialize(), done)
+    self.txTrie.put(rlp.encode(i), new Tx(tx).serialize(), done)
     i++
   }, cb)
 }


### PR DESCRIPTION
the tx is one element in this.transactions, if we want to use tx.serialize(), we should use new Tx(tx).serialize() to replace tx.serialize().
:)