### PR TITLE
New release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [1.7.0] - Unreleased (``master`` branch)
+## [1.7.0] - 2017-10-11
 - ``Metro-Byzantium`` compatible
 - New difficulty formula (EIP 100)
 - Difficulty bomb delay (EIP 649)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-block#readme",
   "dependencies": {
     "async": "^2.0.1",
-    "ethereum-common": "0.2.0",
+    "ethereum-common": "git+https://github.com/ethereumjs/common.git#v0.2.0",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-block",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Provides Block serialization and help functions",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-block#readme",
   "dependencies": {
     "async": "^2.0.1",
-    "ethereum-common": "0.0.18",
+    "ethereum-common": "0.2.0",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"


### PR DESCRIPTION
Versioned Byzantium release, will be published on npm after merge.

Depends on: https://github.com/ethereumjs/common/pull/9

See: https://github.com/ethereumjs/ethereumjs-vm/issues/209