### PR TITLE
Nonce should never be 0 bytes

### DIFF
--- a/header.js
+++ b/header.js
@@ -74,7 +74,7 @@ var BlockHeader = module.exports = function (data) {
       // length: 32
   }, {
     name: 'nonce',
-    default: new Buffer([]) // sha3(42)
+    default: utils.zeros(8) // sha3(42)
   }]
   utils.defineProperties(this, fields, data)
 }
@@ -228,4 +228,3 @@ BlockHeader.prototype.hash = function () {
 BlockHeader.prototype.isGenesis = function () {
   return this.number.toString('hex') === ''
 }
-

--- a/tests/header.js
+++ b/tests/header.js
@@ -23,7 +23,7 @@ tape('[Block]: Header functions', function (t) {
       st.deepEqual(header.timestamp, new Buffer([]))
       st.deepEqual(header.extraData, new Buffer([]))
       st.deepEqual(header.mixHash, utils.zeros(32))
-      st.deepEqual(header.nonce, new Buffer([]))
+      st.deepEqual(header.nonce, utils.zeros(8))
     }
 
     var header = new Header()
@@ -53,4 +53,3 @@ tape('[Block]: Header functions', function (t) {
     st.end()
   })
 })
-


### PR DESCRIPTION
I have a project where we're trying to use Ganache to test our services that
are written in Go. The RPC client that ships with Geth ignores the
hash provided by RPC and recalculates it instead. Due to some discrepancies
between the value used to calculate the hash and the values served over
RPC, the Go client is unable to compute the same hash as Ganache.

One of the issues we ran into was that ethereumjs-block defaults to
an empty nonce, while according to the spec a nonce should be 8 bytes.
When computing the hash, the difference between a 0 byte nonce and
a nonce with 8 null bytes is obviously significant.

With this change along with a couple of changes to Ganache's RPC
encoding, the Ethereum client within Geth computes the same block
hashes as Ganache.