### PR TITLE
Support for different chains / hardfork switches

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@ Creates a new block object
 
 -   `data` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [Buffer](https://nodejs.org/api/buffer.html) \| [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object))** 
 -   `opts` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Options
-    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block ['mainnet']
+    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block [default: 'mainnet']
+    -   `opts.hardfork` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Hardfork for the block [default: null, block number-based behaviour]
+    -   `opts.common` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Alternatively pass a Common instance (ethereumjs-common) instead of setting chain/hardfork directly
 
 **Properties**
 
@@ -106,7 +108,9 @@ An object that repersents the block header
 
 -   `data` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** raw data, deserialized
 -   `opts` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Options
-    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block header ['mainnet']
+    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block header [default: 'mainnet']
+    -   `opts.hardfork` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Hardfork for the block header [default: null, block number-based behaviour]
+    -   `opts.common` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Alternatively pass a Common instance instead of setting chain/hardfork directly
 
 **Properties**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Returns **any** Boolean
 
 ## setGenesisParams
 
-turns the block in to the canonical genesis block
+turns the block into the canonical genesis block
 
 ## serialize
 
@@ -181,3 +181,7 @@ Returns **[Buffer](https://nodejs.org/api/buffer.html)**
 checks if the blockheader is a genesis header
 
 Returns **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## setGenesisParams
+
+turns the header into the canonical genesis block header

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ Creates a new block object
 **Parameters**
 
 -   `data` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [Buffer](https://nodejs.org/api/buffer.html) \| [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object))** 
+-   `opts` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Options
+    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block ['mainnet']
 
 **Properties**
 
@@ -95,3 +97,83 @@ Converts the block toJSON
 -   `labeled` **Bool** whether to create an labeled object or an array
 
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+# BlockHeader
+
+An object that repersents the block header
+
+**Parameters**
+
+-   `data` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** raw data, deserialized
+-   `opts` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** Options
+    -   `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block header ['mainnet']
+
+**Properties**
+
+-   `parentHash` **[Buffer](https://nodejs.org/api/buffer.html)** the blocks' parent's hash
+-   `uncleHash` **[Buffer](https://nodejs.org/api/buffer.html)** sha3(rlp_encode(uncle_list))
+-   `coinbase` **[Buffer](https://nodejs.org/api/buffer.html)** the miner address
+-   `stateRoot` **[Buffer](https://nodejs.org/api/buffer.html)** The root of a Merkle Patricia tree
+-   `transactionTrie` **[Buffer](https://nodejs.org/api/buffer.html)** the root of a Trie containing the transactions
+-   `receiptTrie` **[Buffer](https://nodejs.org/api/buffer.html)** the root of a Trie containing the transaction Reciept
+-   `bloom` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `difficulty` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `number` **[Buffer](https://nodejs.org/api/buffer.html)** the block's height
+-   `gasLimit` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `gasUsed` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `timestamp` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `extraData` **[Buffer](https://nodejs.org/api/buffer.html)** 
+-   `raw` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Buffer](https://nodejs.org/api/buffer.html)>** an array of buffers containing the raw blocks.
+
+## canonicalDifficulty
+
+Returns the canoncical difficulty of the block
+
+**Parameters**
+
+-   `parentBlock` **[Block](#block)** the parent `Block` of the this header
+
+Returns **BN** 
+
+## validateDifficulty
+
+checks that the block's `difficuly` matches the canonical difficulty
+
+**Parameters**
+
+-   `parentBlock` **[Block](#block)** this block's parent
+
+Returns **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## validateGasLimit
+
+Validates the gasLimit
+
+**Parameters**
+
+-   `parentBlock` **[Block](#block)** this block's parent
+
+Returns **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## validate
+
+Validates the entire block header
+
+**Parameters**
+
+-   `blockChain` **Blockchain** the blockchain that this block is validating against
+-   `height` **Bignum?** if this is an uncle header, this is the height of the block that is including it
+-   `cb` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** the callback function. The callback is given an `error` if the block is invalid
+-   `blockchain`  
+
+## hash
+
+Returns the sha3 hash of the blockheader
+
+Returns **[Buffer](https://nodejs.org/api/buffer.html)** 
+
+## isGenesis
+
+checks if the blockheader is a genesis header
+
+Returns **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 

--- a/header.js
+++ b/header.js
@@ -254,3 +254,16 @@ BlockHeader.prototype.hash = function () {
 BlockHeader.prototype.isGenesis = function () {
   return this.number.toString('hex') === ''
 }
+
+/**
+ * turns the header into the canonical genesis block header
+ * @method setGenesisParams
+ */
+BlockHeader.prototype.setGenesisParams = function () {
+  this.gasLimit = this._common.genesis().gasLimit
+  this.difficulty = this._common.genesis().difficulty
+  this.extraData = this._common.genesis().extraData
+  this.nonce = this._common.genesis().nonce
+  this.stateRoot = this._common.genesis().stateRoot
+  this.number = new Buffer([])
+}

--- a/index.js
+++ b/index.js
@@ -98,16 +98,11 @@ Block.prototype.isGenesis = function () {
 }
 
 /**
- * turns the block in to the canonical genesis block
+ * turns the block into the canonical genesis block
  * @method setGenesisParams
  */
 Block.prototype.setGenesisParams = function () {
-  this.header.gasLimit = this._common.genesis().gasLimit
-  this.header.difficulty = this._common.genesis().difficulty
-  this.header.extraData = this._common.genesis().extraData
-  this.header.nonce = this._common.genesis().nonce
-  this.header.stateRoot = this._common.genesis().stateRoot
-  this.header.number = Buffer.from([0])
+  this.header.setGenesisParams()
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-block#readme",
   "dependencies": {
     "async": "^2.0.1",
-    "ethereumjs-common": "^0.1.0",
+    "ethereumjs-common": "^0.3.0",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "karma start karma.conf.js",
     "test:node": "node tests/index.js",
-    "build:docs": "documentation build ./index.js --format md --shallow > ./docs/index.md && documentation build ./from-rpc.js --format md --shallow  > ./docs/fromRpc.md"
+    "build:docs": "documentation build ./index.js ./header.js --format md --shallow > ./docs/index.md && documentation build ./from-rpc.js --format md --shallow  > ./docs/fromRpc.md"
   },
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-block#readme",
   "dependencies": {
     "async": "^2.0.1",
-    "ethereum-common": "0.2.0",
+    "ethereumjs-common": "^0.1.0",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"

--- a/tests/block.js
+++ b/tests/block.js
@@ -1,9 +1,22 @@
 const tape = require('tape')
+const Common = require('ethereumjs-common')
 const testing = require('ethereumjs-testing')
 const rlp = require('ethereumjs-util').rlp
 const Block = require('../index.js')
 
 tape('[Block]: block functions', function (t) {
+  t.test('should test block initialization', function (st) {
+    const block1 = new Block(null, { 'chain': 'ropsten' })
+    const common = new Common('ropsten')
+    const block2 = new Block(null, { 'common': common })
+    block1.setGenesisParams()
+    block2.setGenesisParams()
+    st.strictEqual(block1.hash().toString('hex'), block2.hash().toString('hex'), 'block hashes match')
+
+    st.throws(function () { new Block(null, { 'chain': 'ropsten', 'common': common }) }, /not allowed!$/, 'should throw on initialization with chain and common parameter') // eslint-disable-line
+    st.end()
+  })
+
   const testData = require('./testdata.json')
 
   function testTransactionValidation (st, block) {

--- a/tests/block.js
+++ b/tests/block.js
@@ -34,7 +34,7 @@ tape('[Block]: block functions', function (t) {
     st.end()
   })
 
-  t.test('should test isGenesis', function (st) {
+  t.test('should test isGenesis (mainnet default)', function (st) {
     var block = new Block()
     st.notEqual(block.isGenesis(), true)
     block.header.number = new Buffer([])
@@ -42,13 +42,29 @@ tape('[Block]: block functions', function (t) {
     st.end()
   })
 
+  t.test('should test isGenesis (ropsten)', function (st) {
+    var block = new Block(null, { 'chain': 'ropsten' })
+    st.notEqual(block.isGenesis(), true)
+    block.header.number = new Buffer([])
+    st.equal(block.isGenesis(), true)
+    st.end()
+  })
+
   const testDataGenesis = testing.getSingleFile('BasicTests/genesishashestest.json')
-  t.test('should test genesis hashes', function (st) {
+  t.test('should test genesis hashes (mainnet default)', function (st) {
     var genesisBlock = new Block()
     genesisBlock.setGenesisParams()
     var rlp = genesisBlock.serialize()
     st.strictEqual(rlp.toString('hex'), testDataGenesis.genesis_rlp_hex, 'rlp hex match')
     st.strictEqual(genesisBlock.hash().toString('hex'), testDataGenesis.genesis_hash, 'genesis hash match')
+    st.end()
+  })
+
+  t.test('should test genesis parameters (ropsten)', function (st) {
+    var genesisBlock = new Block(null, { 'chain': 'ropsten' })
+    genesisBlock.setGenesisParams()
+    let ropstenStateRoot = '217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b'
+    st.strictEqual(genesisBlock.header.stateRoot.toString('hex'), ropstenStateRoot, 'genesis stateRoot match')
     st.end()
   })
 

--- a/tests/difficulty.js
+++ b/tests/difficulty.js
@@ -16,12 +16,12 @@ tape('[Header]: difficulty tests', t => {
   function runDifficultyTests (test) {
     normalize(test)
 
-    var parentBlock = new Block()
+    var parentBlock = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
     parentBlock.header.timestamp = test.parentTimestamp
     parentBlock.header.difficulty = test.parentDifficulty
     parentBlock.header.uncleHash = test.parentUncles
 
-    var block = new Block()
+    var block = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
     block.header.timestamp = test.currentTimestamp
     block.header.difficulty = test.currentDifficulty
     block.header.number = test.currentBlockNumber

--- a/tests/difficulty.js
+++ b/tests/difficulty.js
@@ -13,27 +13,57 @@ function normalize (data) {
 }
 
 tape('[Header]: difficulty tests', t => {
-  function runDifficultyTests (test) {
+  t.test('should test error cases', function (st) {
+    var parentBlock = new Block(null, { 'chain': 'mainnet', 'hardfork': 'spuriousDragon' })
+    var block = new Block(null, { 'chain': 'mainnet', 'hardfork': 'spuriousDragon' })
+
+    t.throws(function () { block.header.canonicalDifficulty(parentBlock) }, /Difficulty validation only supported on blocks >= byzantium$/, 'should throw on block with spuriousDragon HF initialization')
+    st.end()
+  })
+
+  function runDifficultyTests (test, parentBlock, block, msg) {
     normalize(test)
 
-    var parentBlock = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
-    parentBlock.header.timestamp = test.parentTimestamp
-    parentBlock.header.difficulty = test.parentDifficulty
-    parentBlock.header.uncleHash = test.parentUncles
-
-    var block = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
-    block.header.timestamp = test.currentTimestamp
-    block.header.difficulty = test.currentDifficulty
-    block.header.number = test.currentBlockNumber
-
     var dif = block.header.canonicalDifficulty(parentBlock)
-    t.equal(dif.toString(), test.currentDifficulty.toString(), 'test canonicalDifficulty')
-    t.assert(block.header.validateDifficulty(parentBlock), 'test validateDifficulty')
+    t.equal(dif.toString(), test.currentDifficulty.toString(), `test canonicalDifficulty (${msg})`)
+    t.assert(block.header.validateDifficulty(parentBlock), `test validateDifficulty (${msg})`)
   }
 
   const testData = require('./testdata-difficulty.json')
   for (let testName in testData) {
-    runDifficultyTests(testData[testName])
+    let test = testData[testName]
+    let parentBlock = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
+    parentBlock.header.timestamp = test.parentTimestamp
+    parentBlock.header.difficulty = test.parentDifficulty
+    parentBlock.header.uncleHash = test.parentUncles
+
+    let block = new Block(null, { 'chain': 'mainnet', 'hardfork': 'byzantium' })
+    block.header.timestamp = test.currentTimestamp
+    block.header.difficulty = test.currentDifficulty
+    block.header.number = test.currentBlockNumber
+
+    runDifficultyTests(test, parentBlock, block, 'fork determination by hardfork param')
+  }
+
+  for (let testName in testData) {
+    let test = testData[testName]
+    const BYZANTIUM_BLOCK = 4370000
+    let parentBlock = new Block()
+    parentBlock.header.timestamp = test.parentTimestamp
+    parentBlock.header.difficulty = test.parentDifficulty
+    parentBlock.header.uncleHash = test.parentUncles
+    parentBlock.header.number = utils.intToBuffer(BYZANTIUM_BLOCK - 1)
+
+    let block = new Block()
+    block.header.timestamp = test.currentTimestamp
+    block.header.difficulty = test.currentDifficulty
+    block.header.number = test.currentBlockNumber
+
+    if (utils.bufferToInt(block.header.number) >= BYZANTIUM_BLOCK) {
+      runDifficultyTests(test, parentBlock, block, 'fork determination by block number')
+    } else {
+      t.throws(function () { block.header.canonicalDifficulty(parentBlock) }, /Difficulty validation only supported on blocks >= byzantium$/, 'should throw on block < byzantium')
+    }
   }
   t.end()
 

--- a/tests/header.js
+++ b/tests/header.js
@@ -1,5 +1,4 @@
 const tape = require('tape')
-const params = require('ethereum-common')
 const utils = require('ethereumjs-util')
 const rlp = utils.rlp
 const testing = require('ethereumjs-testing')
@@ -17,7 +16,7 @@ tape('[Block]: Header functions', function (t) {
       st.equal(header.receiptTrie.toString('hex'), utils.SHA3_RLP_S)
       st.deepEqual(header.bloom, utils.zeros(256))
       st.deepEqual(header.difficulty, new Buffer([]))
-      st.deepEqual(header.number, utils.intToBuffer(params.homeSteadForkNumber.v))
+      st.deepEqual(header.number, utils.intToBuffer(1150000))
       st.deepEqual(header.gasLimit, new Buffer('ffffffffffffff', 'hex'))
       st.deepEqual(header.gasUsed, new Buffer([]))
       st.deepEqual(header.timestamp, new Buffer([]))

--- a/tests/header.js
+++ b/tests/header.js
@@ -1,4 +1,5 @@
 const tape = require('tape')
+const Common = require('ethereumjs-common')
 const utils = require('ethereumjs-util')
 const rlp = utils.rlp
 const testing = require('ethereumjs-testing')
@@ -35,6 +36,18 @@ tape('[Block]: Header functions', function (t) {
     st.end()
   })
 
+  t.test('should test header initialization', function (st) {
+    const header1 = new Header(null, { 'chain': 'ropsten' })
+    const common = new Common('ropsten')
+    const header2 = new Header(null, { 'common': common })
+    header1.setGenesisParams()
+    header2.setGenesisParams()
+    st.strictEqual(header1.hash().toString('hex'), header2.hash().toString('hex'), 'header hashes match')
+
+    st.throws(function () { new Header(null, { 'chain': 'ropsten', 'common': common }) }, /not allowed!$/, 'should throw on initialization with chain and common parameter') // eslint-disable-line
+    st.end()
+  })
+
   t.test('should test validateGasLimit', function (st) {
     const testData = testing.getSingleFile('BlockchainTests/bcBlockGasLimitTest.json')
 
@@ -49,6 +62,22 @@ tape('[Block]: Header functions', function (t) {
     st.equal(header.isGenesis(), false)
     header.number = new Buffer([])
     st.equal(header.isGenesis(), true)
+    st.end()
+  })
+
+  const testDataGenesis = testing.getSingleFile('BasicTests/genesishashestest.json')
+  t.test('should test genesis hashes (mainnet default)', function (st) {
+    var header = new Header()
+    header.setGenesisParams()
+    st.strictEqual(header.hash().toString('hex'), testDataGenesis.genesis_hash, 'genesis hash match')
+    st.end()
+  })
+
+  t.test('should test genesis parameters (ropsten)', function (st) {
+    var genesisHeader = new Header(null, { 'chain': 'ropsten' })
+    genesisHeader.setGenesisParams()
+    let ropstenStateRoot = '217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b'
+    st.strictEqual(genesisHeader.stateRoot.toString('hex'), ropstenStateRoot, 'genesis stateRoot match')
     st.end()
   })
 })


### PR DESCRIPTION
API remains backwards-compatible.

This PR adds optional ``opts`` ``chain`` parameters for both the ``Block`` and the ``BlockHeader``  class, which default to ``mainnet`` if not set. This allows to set the genesis block according to the chain set. Chain-specific parameters are provided by the new [ethereumjs-common](https://github.com/ethereumjs/ethereumjs-common) library which also defines the supported chains.

Note: changes in the API docs diff are so large cause the docs for the ``BlockHeader`` class and functions were not included/forgotten before.