### PR TITLE
Fix BlockHeader.prototype.validate() bug

### DIFF
--- a/header.js
+++ b/header.js
@@ -243,8 +243,8 @@ BlockHeader.prototype.validate = function (blockchain, height, cb) {
       return cb('invalid timestamp')
     }
 
-    const hardfork = this._common.hardfork() ? this._common.hardfork() : this._common.activeHardfork(height)
-    if (self.extraData.length > this._common.param('vm', 'maxExtraDataSize', hardfork)) {
+    const hardfork = self._common.hardfork() ? self._common.hardfork() : self._common.activeHardfork(height)
+    if (self.extraData.length > self._common.param('vm', 'maxExtraDataSize', hardfork)) {
       return cb('invalid amount of extra data')
     }
 


### PR DESCRIPTION
Fixes a ``this`` instead of ``self`` bug in BlockHeader.prototype.validate().

Needs tests, but I wanted to submit a PR to highlight the fix.