### PR TITLE
Add timestamp field to setGenesisParams()

### DIFF
--- a/header.js
+++ b/header.js
@@ -275,6 +275,7 @@ BlockHeader.prototype.isGenesis = function () {
  * @method setGenesisParams
  */
 BlockHeader.prototype.setGenesisParams = function () {
+  this.timestamp = this._common.genesis().timestamp
   this.gasLimit = this._common.genesis().gasLimit
   this.difficulty = this._common.genesis().difficulty
   this.extraData = this._common.genesis().extraData

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-block#readme",
   "dependencies": {
     "async": "^2.0.1",
-    "ethereumjs-common": "^0.3.0",
+    "ethereumjs-common": "^0.5.0",
     "ethereumjs-tx": "^1.2.2",
     "ethereumjs-util": "^5.0.0",
     "merkle-patricia-tree": "^2.1.2"

--- a/tests/block.js
+++ b/tests/block.js
@@ -73,6 +73,22 @@ tape('[Block]: block functions', function (t) {
     st.end()
   })
 
+  t.test('should test genesis hashes (ropsten)', function (st) {
+    var common = new Common('ropsten')
+    var genesisBlock = new Block(null, { common: common })
+    genesisBlock.setGenesisParams()
+    st.strictEqual(genesisBlock.hash().toString('hex'), common.genesis().hash.slice(2), 'genesis hash match')
+    st.end()
+  })
+
+  t.test('should test genesis hashes (rinkeby)', function (st) {
+    var common = new Common('rinkeby')
+    var genesisBlock = new Block(null, { common: common })
+    genesisBlock.setGenesisParams()
+    st.strictEqual(genesisBlock.hash().toString('hex'), common.genesis().hash.slice(2), 'genesis hash match')
+    st.end()
+  })
+
   t.test('should test genesis parameters (ropsten)', function (st) {
     var genesisBlock = new Block(null, { 'chain': 'ropsten' })
     genesisBlock.setGenesisParams()
@@ -88,4 +104,3 @@ tape('[Block]: block functions', function (t) {
     st.end()
   })
 })
-


### PR DESCRIPTION
Currently, genesis block hashes are computed incorrectly for the Rinkeby network since the timestamp field is not included. This PR fixes that.
