### PR TITLE
Fix package size issue (post-added to v2.2.0 release from #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ support/readiness by updating to a supporting `ethereumjs-common` version
 PR [#64](https://github.com/ethereumjs/ethereumjs-block/pull/64)
 
 **Other Changes:**
+- Fixed package size issue by excluding tests and docs from being included in 
+  the package, PR [#66](https://github.com/ethereumjs/ethereumjs-block/pull/66)
 - Error message fixes in `index.js`,
   PR [#62](https://github.com/ethereumjs/ethereumjs-block/pull/62)
 - Replace uses of deprecated `new Buffer` with `Buffer.from`,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.2.0",
   "description": "Provides Block serialization and help functions",
   "main": "index.js",
+  "files": [
+    "*.js"
+  ],
   "scripts": {
     "coverage": "istanbul cover ./tests/index.js",
     "coveralls": "npm run coverage && coveralls < coverage/lcov.info",


### PR DESCRIPTION
Just realized that npm package includes both `tests` and `docs` folder leading to huge bundle sizes. I would like to post-add this to the release (haven't published yet) since this is not really acceptable, so I have also added this to the CHANGELOG and will `npm publish` with this merged.

Here is the output before/after:

```shell
npm notice 📦  ethereumjs-block@2.2.0
npm notice === Tarball Contents ===
npm notice 1.7kB   package.json
npm notice 679B    .travis.yml
npm notice 4.6kB   CHANGELOG.md
npm notice 1.9kB   from-rpc.js
npm notice 1.1kB   header-from-rpc.js
npm notice 9.1kB   header.js
npm notice 8.2kB   index.js
npm notice 1.1kB   karma.conf.js
npm notice 16.7kB  LICENSE
npm notice 1.3kB   README.md
npm notice 652B    docs/fromRpc.md
npm notice 7.9kB   docs/index.md
npm notice 342.8kB tests/bcBlockGasLimitTest.json
npm notice 3.9kB   tests/block.js
npm notice 3.1kB   tests/difficulty.js
npm notice 777.7kB tests/difficultyByzantium.json
npm notice 777.9kB tests/difficultyConstantinople.json
npm notice 777.8kB tests/difficultyFrontier.json
npm notice 777.7kB tests/difficultyHomestead.json
npm notice 777.7kB tests/difficultyMainNetwork.json
npm notice 777.7kB tests/difficultyRopstenByzantium.json
npm notice 777.7kB tests/difficultyRopstenConstantinople.json
npm notice 485B    tests/from-rpc.js
npm notice 1.5kB   tests/genesishashestest.json
npm notice 3.5kB   tests/header.js
npm notice 97B     tests/index.js
npm notice 5.9kB   tests/testdata-from-rpc.json
npm notice 10.3kB  tests/testdata.json
npm notice 15.6kB  tests/testdata2.json
npm notice === Tarball Details ===
npm notice name:          ethereumjs-block
npm notice version:       2.2.0
npm notice package size:  702.8 kB
npm notice unpacked size: 5.9 MB
npm notice shasum:        ddfe22d5cf276faa618cc6f7dce4db799b9a4911
npm notice integrity:     sha512-5MEaSglFyeOC0[...]OpW5V95pmHpEg==
npm notice total files:   29
npm notice
```

```shell
npm notice 📦  ethereumjs-block@2.2.0
npm notice === Tarball Contents ===
npm notice 1.7kB  package.json
npm notice 4.6kB  CHANGELOG.md
npm notice 1.9kB  from-rpc.js
npm notice 1.1kB  header-from-rpc.js
npm notice 9.1kB  header.js
npm notice 8.2kB  index.js
npm notice 1.1kB  karma.conf.js
npm notice 16.7kB LICENSE
npm notice 1.3kB  README.md
npm notice === Tarball Details ===
npm notice name:          ethereumjs-block
npm notice version:       2.2.0
npm notice filename:      ethereumjs-block-2.2.0.tgz
npm notice package size:  13.7 kB
npm notice unpacked size: 45.8 kB
npm notice shasum:        750c8d978600714a6e5dafae34f898de16c84166
npm notice integrity:     sha512-RQUF9Px/WvRzJ[...]7Iuz9nXF14z5w==
npm notice total files:   9
npm notice
```

Again: quick review would be good.