### PR TITLE
Removing duplicated job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
       node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=test:node
     - os: linux
-      node_js: "8"
-      env: CXX=g++-4.8 TEST_SUITE=test:node
-    - os: linux
       node_js: "10"
       env: CXX=g++-4.8 TEST_SUITE=test:node
     - os: linux


### PR DESCRIPTION
There are two jobs in Travis matrix with the exact same environment variables. They seem to be duplicated.

