### PR TITLE
Adding script to wrap tests copied from ethereum/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This module work with `browserify`.
 
 Tests in the `tests` directory are partly outdated and testing is primarily done by running the `BlockchainTests` from within the [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) repository.
 
+To avoid bloating this repository with [ethereum/test](https://github.com/ethereum/tests) JSON files, we usually copy specific JSON files and wrap them with some metadata (source, date, commit hash). There's a helper to aid on that process and can be found at [wrap-ethereum-test.sh](https://github.com/ethereumjs/ethereumjs-block/blob/master/scripts/wrap-ethereum-test.sh).
+
 # EthereumJS
 
 See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.

--- a/scripts/wrap-ethereum-test.sh
+++ b/scripts/wrap-ethereum-test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# It wraps the provided JSON file and adds some metadata to it (source, commit, date).
+# Based on these instructions: https://github.com/ethereumjs/ethereumjs-block/issues/55
+#
+# Usage: 
+# ./wrap-ethereum-test.sh "https://raw.githubusercontent.com/ethereum/tests/eea4bfbeec5524b2e2c0ff84c8a350fcb3edec23/BasicTests/difficultyEIP2384.json"
+# The url must contain the commit hash and should point to a raw JSON file
+#
+
+URL=$1
+
+DATE=`date +%Y-%m-%d`
+COMMIT=$(echo "$URL" | sed -E 's/.+\/([a-f0-9]+)\/.+/\1/')
+FILENAME=$(echo $URL | sed -E 's/.+\/([^\/]+)$/\1/')
+
+echo "URL: $URL\nFILENAME: $FILENAME\nDATE: $DATE" 
+
+curl $URL | jq -r --arg SOURCE "$URL" --arg COMMIT "$COMMIT" --arg DATE "$DATE" '{ source: $SOURCE, commit: $COMMIT, date: $DATE, tests: .}' > $FILENAME


### PR DESCRIPTION
It wraps the provided JSON file, adding some metadata to it (source, commit, date). Based on the instructions provided by @holgerd77: https://github.com/ethereumjs/ethereumjs-block/issues/55.

Usage: 

```bash
./wrap-ethereum-test.sh "https://raw.githubusercontent.com/ethereum/tests/eea4bfbeec5524b2e2c0ff84c8a350fcb3edec23/BasicTests/difficultyEIP2384.json"
```
Output example: https://github.com/ethereumjs/ethereumjs-block/blob/df74bb25bcf1b56ef733705faa65df0caa89098d/test/difficultyEIP2384.json

