### PR TITLE
docs: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Implements schema and functions related to Ethereum's block.
 
 # BROWSER
 
-This module work with `browserify`.
+This module works with `browserify`.
 
 # API
 
-[./docs](./docs/index.md)
+[./docs](./docs/README.md)
 
 # TESTING
 
 Tests in the `tests` directory are partly outdated and testing is primarily done by running the `BlockchainTests` from within the [ethereumjs-vm](https://github.com/ethereumjs/ethereumjs-vm) repository.
 
-To avoid bloating this repository with [ethereum/tests](https://github.com/ethereum/tests) JSON files, we usually copy specific JSON files and wrap them with some metadata (source, date, commit hash). There's a helper to aid on that process and can be found at [wrap-ethereum-test.sh](https://github.com/ethereumjs/ethereumjs-block/blob/master/scripts/wrap-ethereum-test.sh).
+To avoid bloating this repository with [ethereum/tests](https://github.com/ethereum/tests) JSON files, we usually copy specific JSON files and wrap them with some metadata (source, date, commit hash). There's a helper to aid in that process and can be found at [wrap-ethereum-test.sh](https://github.com/ethereumjs/ethereumjs-block/blob/master/scripts/wrap-ethereum-test.sh).
 
 # EthereumJS
 


### PR DESCRIPTION
### What does it do?
Fixes link to the API docs (and couple other small grammar tweaks).